### PR TITLE
Bump numpy version to 1.22.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # core deps
-numpy==1.22.0;python_version<="3.10"
+numpy==1.22.4;python_version<="3.10"
 numpy==1.24.3;python_version>"3.10"
 cython==0.29.30
 scipy>=1.11.2


### PR DESCRIPTION
numpy 1.22.0 has a bug that limits logging globally, forcing third party libraries (not only numpy logger) to a certain log level, which suppresses log, even if it is explicitly set up to a different level.  
numpy 1.22.4 does not have that issue.